### PR TITLE
Enable CI in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: docker-compose run --rm tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run tests
         run: docker-compose run --rm tests
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run plugin linter
+        run: docker-compose run --rm lint

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For secrets in the same AWS account as the agent, you can use the secret name ra
 steps:
   - commands: 'echo \$MY_SECRET'
     plugins:
-      - seek-oss/aws-sm#v2.3.2:
+      - commonlit/aws-sm#v2.3.2:
           env:
             MY_SECRET: my-secret-id
             MY_OTHER_SECRET: my-other-secret-id
@@ -66,7 +66,7 @@ For Secrets in JSON (e.g. you're using AWS SMs key=value support), a `jq`-compat
 steps:
   - commands: 'echo \$MY_SECRET'
     plugins:
-      - seek-oss/aws-sm#v2.3.2:
+      - commonlit/aws-sm#v2.3.2:
           env:
             MY_SECRET:
               secret-id: "my-secret-id"
@@ -80,7 +80,7 @@ steps:
 steps:
   - commands: 'echo \$MY_SECRET'
     plugins:
-      - seek-oss/aws-sm#v2.3.2:
+      - commonlit/aws-sm#v2.3.2:
           json-to-env:
             - secret-id: "my-secret-id"
               json-key: ".Variables"
@@ -113,7 +113,7 @@ For secrets in another AWS account, use the secret ARN.
 steps:
   - commands: 'echo \$SECRET_FROM_OTHER_ACCOUNT'
     plugins:
-      - seek-oss/aws-sm#v2.3.2:
+      - commonlit/aws-sm#v2.3.2:
           env:
             SECRET_FROM_OTHER_ACCOUNT: "arn:aws:secretsmanager:ap-southeast-2:1234567:secret:my-global-secret"
           file:
@@ -130,7 +130,7 @@ In this case, you can either use the ARN syntax to deduce the region from the se
 steps:
   - commands: 'echo \$SECRET_FROM_OTHER_REGION'
     plugins:
-      - seek-oss/aws-sm#v2.3.2:
+      - commonlit/aws-sm#v2.3.2:
           region: us-east-1
           env:
             SECRET_FROM_OTHER_REGION: my-secret-id
@@ -145,7 +145,7 @@ for increased security.
 steps:
   - commands: 'echo \$MY_SECRET'
     plugins:
-      - seek-oss/aws-sm#v2.3.2:
+      - commonlit/aws-sm#v2.3.2:
           endpoint-url: https://vpce-12345-abcd.secretsmanager.us-east-1.vpce.amazonaws.com
           env:
             MY_SECRET: my-secret-id
@@ -160,7 +160,7 @@ It's thus possible to use secrets from this plugin in another plugin:
 steps:
   - command: npm publish
     plugins:
-      - seek-oss/aws-sm#v2.3.2:
+      - commonlit/aws-sm#v2.3.2:
           env:
             MY_TOKEN: npm-publish-token
       - seek-oss/private-npm#v1.1.1:
@@ -175,7 +175,7 @@ Note that if you're using the [Docker plugin](https://github.com/buildkite-plugi
 steps:
   - command: echo $$MY_SECRET
     plugins:
-      - seek-oss/aws-sm#v2.3.2:
+      - commonlit/aws-sm#v2.3.2:
           env:
             MY_SECRET: the-secret-id
       - docker#v1.4.0:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 services:
   tests:
     build:
@@ -7,7 +7,6 @@ services:
       - ".:/plugin:ro"
   lint:
     image: buildkite/plugin-linter
-    command: ['--name', 'seek-oss/aws-sm']
+    command: ["--name", "commonlit/aws-sm"]
     volumes:
       - ".:/plugin:ro"
-


### PR DESCRIPTION
This change enables CI checks in our fork of the repository so we can confirm tests are passing with any future changes.